### PR TITLE
Downgrade to python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # DOCKER-VERSION 17.10.0-ce
-FROM python:3.10-slim-buster
+FROM python:3.9-slim-buster
 MAINTAINER Giuseppe De Marco <giuseppe.demarco@unical.it>
 
 # set environment variables


### PR DESCRIPTION
After the automatic upgrade to python 3.10 dockerfile doesn't compile properly. It is because the following line in dockerfile that still refers to python 3.9:
`RUN cp /usr/local/lib/python3.9/site-packages/bootstrap_italia_template/templates/bootstrap-italia-base.html templates/base-setup.html`

If i change it to python 3.10 it still doesn't compile returning the following error:
`=> ERROR [16/18] RUN python manage.py migrate                                                                                                                                                                              0.9s 
 > [16/18] RUN python manage.py migrate:
#21 0.884 Traceback (most recent call last):
#21 0.885   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
#21 0.885   File "/uniTicket/uni_ticket_project/settings.py", line 24, in <module>
#21 0.885     from . settingslocal import *
#21 0.885   File "/uniTicket/uni_ticket_project/settingslocal.py", line 330, in <module>
#21 0.885     ADDITIONAL_USER_FIELDS = [uni_ticket_settings.EMPLOYEE_ATTRIBUTE_NAME,
#21 0.885 NameError: name 'uni_ticket_settings' is not defined

failed to solve: rpc error: code = Unknown desc = executor failed running [/bin/sh -c python manage.py migrate]: exit code: 1`

If I downgrade the version of python to 3.9 (as in the commit of PR) it works properly.