### PR TITLE
Fix print error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
     && apt-get install -y poppler-utils git locales xmlsec1 gcc \
                           libmagic-dev libmariadbclient-dev libssl-dev \
                           libsasl2-dev libldap2-dev net-tools tcpdump \
-                          curl iproute2 libgtk2.0-0 \
+                          curl iproute2 libgtk2.0-0 libpango1.0.0\
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -72,7 +72,7 @@ cryptojwt>=1.5.0
 #   sudo apt install -f
 # ]
 
-WeasyPrint>=52.4
+WeasyPrint==52.4
 # django-wkhtmltopdf>=3.3.0
 # pdfkit>=0.6.1
 # pypdf2>=1.26.0


### PR DESCRIPTION
After a clean installation printing feature doesn't work. 
It returns the following error page:
![image](https://user-images.githubusercontent.com/34674832/143004616-ff4c8a9a-059c-4957-afe9-2e6a0fbb42b7.png)

Installing libpango with apt and fixing the version of WeasyPrint make it work again
