### PR TITLE
Fix naming in README and gitignore .csr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ saml2_sp/saml2_config/certificates/*key
 saml2_sp/saml2_config/certificates/*src
 saml2_sp/saml2_config/certificates/*crt
 saml2_sp/saml2_config/certificates/*cert
+saml2_sp/saml2_config/certificates/*csr
 saml2_sp/saml2_config/settings.py
 saml2_sp/saml2_config/metadata/
 

--- a/saml2_sp/saml2_config/certificates/README.txt
+++ b/saml2_sp/saml2_config/certificates/README.txt
@@ -1,6 +1,6 @@
-openssl genrsa -out sp-key.pem 2048
-openssl req -new -key sp-key.pem -out sp.csr
-openssl x509 -req -days 3650 -in sp.csr -signkey sp-key.pem -out sp.crt
+openssl genrsa -out key.pem 2048
+openssl req -new -key key.pem -out sp.csr
+openssl x509 -req -days 3650 -in sp.csr -signkey key.pem -out sp.crt
 
 # convert them to pem
 openssl x509 -inform PEM -in sp.crt > sp-cert.pem


### PR DESCRIPTION
Commands in certificates README generates sp-key.pem, instead the system searches for a key.pem, so it will be good if the readme gives the commands with the right naming. The commands also generate a .csr file which should be ignored by git.