### PR TITLE
fix: Precompiled module - next web path is now aware of multiple ? chars

### DIFF
--- a/uniticket/uni_ticket/views/user.py
+++ b/uniticket/uni_ticket/views/user.py
@@ -6,7 +6,7 @@ import re
 import shutil
 from typing import Union
 
-
+from django.contrib.auth import REDIRECT_FIELD_NAME
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin.models import LogEntry
@@ -454,11 +454,17 @@ class TicketAddNew(View):
         if not self.category.is_published():
             unavailable_msg = self.category.not_available_message or UNAVAILABLE_TICKET_CATEGORY
             return custom_message(self.request, unavailable_msg, status=404)
-
+        
+        # TODO: not covered yet in the unit tests
         # if anonymous user and category only for logged users
         if not self.category.allow_anonymous and not self.request.user.is_authenticated:
-            redirect_url = "{}?next={}".format(
-                settings.LOGIN_URL, self.request.get_full_path())
+            _sep = "?"
+            if sep in settings.LOGIN_URL:
+                _sep = "&"
+            redirect_url = "{}{}{}={}".format(
+                settings.LOGIN_URL, _sep, 
+                REDIRECT_FIELD_NAME, self.request.get_full_path()
+            )
             return redirect(redirect_url)
 
         # is user is authenticated

--- a/uniticket/uni_ticket_project/settingslocal.py.example
+++ b/uniticket/uni_ticket_project/settingslocal.py.example
@@ -51,16 +51,20 @@ EMAIL_SENDER = f'ticket.no-reply@{HOSTNAME}'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
-        'NAME': 'db_name',
-        'HOST': 'db_host',
-        'USER': 'db_user',
-        'PASSWORD': 'db_password',
-        'PORT': '',
-        'OPTIONS': {
-            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
-        },
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
+#    'default': {
+#        'ENGINE': 'django.db.backends.mysql',
+#        'NAME': 'db_name',
+#        'HOST': 'db_host',
+#        'USER': 'db_user',
+#        'PASSWORD': 'db_password',
+#        'PORT': '',
+#        'OPTIONS': {
+#            'init_command': "SET sql_mode='STRICT_TRANS_TABLES'",
+#        },
+#    }
 }
 
 # Application definition


### PR DESCRIPTION
Questa PR risolve un problema latente che ho scoperto grazie al tracelog condiviso da @cappuccia-agid-gov-it con la nota

````
 In pratica se invio il link di apertura di un ticket il programma restituisce un 500 invece di mostrare la form di login.
````

il tracelog è

````
  File "./spid_oidc_rp/views.py", line 58, in get_oidc_rp_issuer
    return issuer_id, available_issuers[issuer_id]['issuer']
````

apparentemente la problematica riguardava il componente oidc rp, da una attenta analisi ci siamo resi conto che l'eccezione emergeva perché il parametro `issuer` non era valorizzato nell'url di redirect che uniticket presenta agli utenti non loggati.

analizzando tale url abbiamo notato che ben due caratteri `?` erano presenti e che a causa di questo issuer non veniva considerato.

In aggiunta a questa PR e con il presupposto che in AgID il parametro `next` debba essere customizzato per compatibilità con AgID Login, ho aperto una PR di proposta in django, per rendere questo parametro configurabile all'interno del settings di progetto. FYI la PR su django è qui:

https://github.com/django/django/pull/16168